### PR TITLE
add chromote environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ ENV TZ=Etc/UTC
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
+# See https://rstudio.github.io/chromote/news/index.html#chromote-030
+# To be fixed in the new development version so this line will go away soon
+ENV CHROMOTE_HEADLESS="new"
+
 COPY rocker_scripts/scripts /rocker_scripts
 RUN /rocker_scripts/install_R_source.sh && \
     /rocker_scripts/setup_R.sh && \


### PR DESCRIPTION
- The new version of chrome has changed the headless mode.
- Until a definite release chromote offers the options of the two modes coexisting
- To change to the new mode we have to include a new environment variable


https://rstudio.github.io/chromote/news/index.html#chromote-030