### PR TITLE
include_pdf_latex

### DIFF
--- a/scripts/install_sys_deps.sh
+++ b/scripts/install_sys_deps.sh
@@ -10,6 +10,7 @@ qpdf \
 wget \
 texlive-latex-base\
 "
+# texlive-latex-base because it contains `pdflatex`
 apt-get update -y
 # shellcheck disable=SC2086
 apt-get install -q -y ${pkgs_to_install}

--- a/scripts/install_sys_deps.sh
+++ b/scripts/install_sys_deps.sh
@@ -8,6 +8,7 @@ lbzip2 \
 rsync \
 qpdf \
 wget \
+texlive-latex-base\
 "
 apt-get update -y
 # shellcheck disable=SC2086


### PR DESCRIPTION
The `pdflatex` package is not found in the new image (in fact, the package is installed but after autoremoved). Without it, manuals cannot be checked when `rcmdcheck` runs.

- In the previous image it was also not installed, nonetheless checks run fine without it.
- Unclear why in this new set of versions it becomes a requirement
- No relevant documentation or information was found regarding this discrepancy.

Proposed Solution:
To resolve the issue, explicitly install the `pdflatex` package in the new image. Unclear if further investigation about the origin of the discrepancy will bring any extra benefit.