### PR TITLE
Revert "Merge pull request #14 from Boehringer-Ingelheim/include_pdf_…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,10 @@ RUN /rocker_scripts/install_R_source.sh && \
 
 COPY scripts /scripts
 RUN /scripts/install_sys_deps.sh && \
-    /scripts/install_r_pkgs.R 
+    /scripts/install_r_pkgs.R
+
+# TinyTex is installed in /root/.TinyTex and then linked to /root/bin, for it to be found we link to a location found in PATH
+RUN ln -s /root/.TinyTeX/bin/*/* /usr/local/bin/
 
 # Cleanup
 RUN rm -rf /rocker_scripts /scripts 

--- a/scripts/install_sys_deps.sh
+++ b/scripts/install_sys_deps.sh
@@ -8,9 +8,7 @@ lbzip2 \
 rsync \
 qpdf \
 wget \
-texlive-latex-base\
 "
-# texlive-latex-base because it contains `pdflatex`
 apt-get update -y
 # shellcheck disable=SC2086
 apt-get install -q -y ${pkgs_to_install}


### PR DESCRIPTION
This reverts commit aea1c66d858eb7192a2358b06bb7306fb83e8151, reversing changes made to 7820ba09a1af7cd8397a6e812ca22b98f2d641d2.

`pdflatex` was installed but it was not linked properly. The problem is that it was not found because it was not in the `PATH`

It is installed in `/root/bin` which is not in the `PATH`.

The proposed solution is to link it into `/usr/local/bin` which in `PATH`.

As in #14 the origin in unclear, same logic applies that the ROI of finding out seems low.
