### PR TITLE
Use texlive instead of tinytex

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           repository: rocker-org/rocker-versioned2
           path: ./rocker_scripts
-          ref: master
+          ref: abe4fc1f3fb1c50281f9de5b3636f8a117126f98
 
       - name: Set up Docker Buildx 📐
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Checkout project ⬇️
         uses: actions/checkout@v4
 
+      # NOTE(miguel): We point to the latest commit on the `master` branch of rocker-version2 (2025-03-25)
+      # This may break our builds for future versions of R, but we will stop depending on these scripts 
+      # long before that can happen.
       - name: Checkout Rocker project ⬇️
         uses: actions/checkout@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ARG PANDOC_VERSION=2.9.2.1
 ARG QUARTO_VERSION=1.3.450
 # https://github.com/lycheeverse/lychee/releases/
 ARG LYCHEE_VERSION=0.15.1
+ARG EXPECTED_LYCHEE_MD5SUM=9e6530526c89819ac9690f234ec952e2
 
 # Set up environment 
 ENV R_HOME=/usr/local/lib/R

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ FROM ${OS_NAME}:${OS_VERSION}
 ARG R_VERSION=latest
 ARG CRAN=https://packagemanager.posit.co/cran/__linux__/jammy/latest
 
+# preserve texlive
+ARG PURGE_BUILDDEPS=false
+
 # https://github.com/jgm/pandoc/tags
 ARG PANDOC_VERSION=2.9.2.1
 # https://github.com/quarto-dev/quarto-cli/tags
@@ -35,9 +38,6 @@ ENV CHROMOTE_CHROME=/usr/bin/chromium-headless-shell
 
 RUN /scripts/install_sys_deps.sh && \
     /scripts/install_r_pkgs.R
-
-# TinyTex is installed in /root/.TinyTex and then linked to /root/bin, for it to be found we link to a location found in PATH
-RUN ln -s /root/.TinyTeX/bin/*/* /usr/local/bin/
 
 # Cleanup
 RUN rm -rf /rocker_scripts /scripts 

--- a/scripts/install_r_pkgs.R
+++ b/scripts/install_r_pkgs.R
@@ -5,7 +5,6 @@ install.packages("pak")
 
 # Packages to install
 install_pkgs <- c(
-  "tinytex",
   "rcmdcheck",
   "roxygen2",
   "lintr",
@@ -31,9 +30,6 @@ pak::pak(
   ask = FALSE,
   upgrade = FALSE
 )
-
-# Install tinytex
-tinytex::install_tinytex()
 
 # Remove DaVinci packages from image
 grep("^dv.", rownames(installed.packages()), value = TRUE) |> sapply(remove.packages)

--- a/scripts/install_sys_deps.sh
+++ b/scripts/install_sys_deps.sh
@@ -19,4 +19,10 @@ apt-get autoclean -y
 rm -rf /var/lib/apt/lists/*
 
 # Install lychee URL checker
-curl -Ls https://github.com/lycheeverse/lychee/releases/download/v"${LYCHEE_VERSION}"/lychee-v"${LYCHEE_VERSION}"-"$(arch)"-unknown-linux-gnu.tar.gz | tar xz -C /usr/local/bin
+
+curl -Ls https://github.com/lycheeverse/lychee/releases/download/v"${LYCHEE_VERSION}"/lychee-v"${LYCHEE_VERSION}"-"$(arch)"-unknown-linux-gnu.tar.gz --output-dir /tmp/
+lychee_md5sum=$(md5sum /tmp/lychee-v"${LYCHEE_VERSION}"-"$(arch)"-unknown-linux-gnu.tar.gz | cut -d ' ' -f 1)
+if [ "$lychee_md5sum" != "$EXPECTED_LYCHEE_MD5SUM" ]; then
+    exit 1
+fi
+tar xz -f /tmp/lychee-v"${LYCHEE_VERSION}"-"$(arch)"-unknown-linux-gnu.tar.gz -C /usr/local/bin

--- a/scripts/install_sys_deps.sh
+++ b/scripts/install_sys_deps.sh
@@ -20,9 +20,9 @@ rm -rf /var/lib/apt/lists/*
 
 # Install lychee URL checker
 
-curl -Ls https://github.com/lycheeverse/lychee/releases/download/v"${LYCHEE_VERSION}"/lychee-v"${LYCHEE_VERSION}"-"$(arch)"-unknown-linux-gnu.tar.gz --output-dir /tmp/
-lychee_md5sum=$(md5sum /tmp/lychee-v"${LYCHEE_VERSION}"-"$(arch)"-unknown-linux-gnu.tar.gz | cut -d ' ' -f 1)
+curl -Ls https://github.com/lycheeverse/lychee/releases/download/v"${LYCHEE_VERSION}"/lychee-v"${LYCHEE_VERSION}"-"$(arch)"-unknown-linux-gnu.tar.gz --output-dir /tmp/ -o lychee.tar.gz
+lychee_md5sum=$(md5sum /tmp/lychee.tar.gz | cut -d ' ' -f 1)
 if [ "$lychee_md5sum" != "$EXPECTED_LYCHEE_MD5SUM" ]; then
     exit 1
 fi
-tar xz -f /tmp/lychee-v"${LYCHEE_VERSION}"-"$(arch)"-unknown-linux-gnu.tar.gz -C /usr/local/bin
+tar xz -f /tmp/lychee.tar.gz -C /usr/local/bin


### PR DESCRIPTION
Hi!

This PR removes tinytex from the CI/CD image and replaces it with a regular texlive installation. It does so by setting the environment variable
> export PURGE_BUILDDEPS=false

which forces the image to retain intermediate install dependencies pulled by `rocker_scripts/install_R_source.sh`.

To reduce the chance of a supply-chain attack I've also:
- Hardcoded the commit that we use to get rocker scripts
- Check that the downloaded lychee binary matches a known md5 sum.

I've run the generated docker image on these two repos:
- [dv.listings](https://github.com/Boehringer-Ingelheim/dv.listings/actions/runs/14042248474), because it depends on pdflatex generation of documents.
- [dv.explorer.parameter](https://github.com/Boehringer-Ingelheim/dv.explorer.parameter/actions/runs/14042221755), because it has many modules and famously finicky snapshots, so it's a good canary in the coal mine for stuff that could go wrong with other packages.

All test pass. The time to run them seems unaffected by the inclusion of the (very comprehensive) texlive installation.
I think this new image is fit for use and should fail less often than the one currently tagged as `latest`.

However, be aware that the size of the image has ballooned from 4.17 GiB to 7.15 GiB.
I believe around 2 GiB of those belong to texlive and the rest includes dependencies that we keep downloading for every step of every of our pipeline runs. So on balance, I think we're OK.

I'm quite unhappy with the half-baked set of scripts tangled in github actions that we have now, because I haven't figured out how to reproduce the build locally. So, if in the future we decide to go for a more thorough rewrite of the CI/CD image, I think we should look for the rocker image that most closely matches our needs and use that as our base layer.